### PR TITLE
Ignore /gradle.properties so that developers can put their passwords of Sonatype and their OpenPGP key to sign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.gradle
+/gradle.properties
 /build/


### PR DESCRIPTION
Just adding in `.gitignore`.