### PR TITLE
Upgrade Guice to 4.2.0 to be compatible with JDK 10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ javadoc {
 }
 
 dependencies {
-    compile 'com.google.inject:guice:4.0'
+    compile 'com.google.inject:guice:4.2.0'
     testCompile 'org.testng:testng:6.9.9'
 }
 

--- a/src/test/java/org/embulk/guice/TestBootstrap.java
+++ b/src/test/java/org/embulk/guice/TestBootstrap.java
@@ -59,7 +59,7 @@ public class TestBootstrap
             Assert.fail("should not allow circular dependencies");
         }
         catch (ProvisionException e) {
-            assertContains(e.getErrorMessages().iterator().next().getMessage(), "circular proxies are disabled");
+            assertContains(e.getErrorMessages().iterator().next().getMessage(), "circular dependencies are disabled");
         }
     }
 


### PR DESCRIPTION
Guice prior to 4.2.0 throws an error with JDK 9 or 10. This change
upgrades Guice version to be compatible with JDK 10.

Changes of Guice:

* https://github.com/google/guice/wiki/Guice41
* https://github.com/google/guice/wiki/Guice42