### PR TITLE
Use java.util.function.Function instead of Guava Function, and prepare for v0.3.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Release 0.3.2 - 2018-09-27
+
+* Deprecate the usage of Guava's Function, and use java.util.function.Function
+
+
 Release 0.3.1 - 2018-06-13
 
 * Depend on Guice 4.2.0 to make it work with JDK 10

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: "signing"
 
 group = "org.embulk"
 archivesBaseName = "${project.name}"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.2-SNAPSHOT"
 description "Guice-bootstrap adds JSR 250 Life Cycle annotations to Google Guice"
 
 repositories {

--- a/src/main/java/org/embulk/guice/Bootstrap.java
+++ b/src/main/java/org/embulk/guice/Bootstrap.java
@@ -15,7 +15,6 @@
  */
 package org.embulk.guice;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -28,6 +27,7 @@ import com.google.inject.Stage;
 import com.google.inject.util.Modules;
 
 import java.util.List;
+import java.util.function.Function;
 
 public class Bootstrap
 {
@@ -94,6 +94,19 @@ public class Bootstrap
                 return ImmutableList.of(Modules.override(modules).with(immutableCopy));
             }
         });
+    }
+
+    @Deprecated  // Using Guava's Function is deprecated.
+    public Bootstrap overrideModules(final com.google.common.base.Function<? super List<Module>, ? extends Iterable<? extends Module>> function)
+    {
+        final Function<? super List<Module>, ? extends Iterable<? extends Module>> wrapper =
+                new Function<List<Module>, Iterable<? extends Module>>() {
+                    public Iterable<? extends Module> apply(final List<Module> modules) {
+                        return function.apply(modules);
+                    }
+                };
+        moduleOverrides.add(wrapper);
+        return this;
     }
 
     public Bootstrap overrideModules(Function<? super List<Module>, ? extends Iterable<? extends Module>> function)


### PR DESCRIPTION
Guava's `Function` is discouraged to use in Java 8+. It is recommended to use Java 8's `java.util.function.Function` instead.

https://google.github.io/guava/releases/23.0/api/docs/com/google/common/base/Function.html

It replaces Guava's `Function` to Java 8's with deprecating the old Guava-based method with wrapping.

@kamatama41 Can you have a look when you have time? We can talk about this f2f later.
(Cc: @sakama)