### PR TITLE
Upgrade to Guice 5.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ javadoc {
 }
 
 dependencies {
-    compile 'com.google.inject:guice:4.2.0'
+    compile 'com.google.inject:guice:5.0.1'
     testCompile 'org.testng:testng:6.9.9'
 }
 

--- a/src/main/java/org/embulk/guice/LifeCycleInjectorProxy.java
+++ b/src/main/java/org/embulk/guice/LifeCycleInjectorProxy.java
@@ -16,6 +16,12 @@
 package org.embulk.guice;
 
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.Element;
+import com.google.inject.spi.InjectionPoint;
+
+import java.util.List;
+import java.util.Map;
 
 class LifeCycleInjectorProxy
         extends InjectorProxy
@@ -55,5 +61,17 @@ class LifeCycleInjectorProxy
     public void close() throws Exception
     {
         destroy();
+    }
+
+    @Override
+    public List<Element> getElements()
+    {
+        return injector.getElements();
+    }
+
+    @Override
+    public Map<TypeLiteral<?>, List<InjectionPoint>> getAllMembersInjectorInjectionPoints()
+    {
+        return injector.getAllMembersInjectorInjectionPoints();
     }
 }


### PR DESCRIPTION
Bump Guice to version 5.0.1 and implement the (new) missing methods in `LifeCycleInjectorProxy`.

Release notes for Guice 5.0.1:
https://github.com/google/guice/wiki/Guice501